### PR TITLE
Remove NextAuth route handler

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,2 +1,0 @@
-import { handlers } from "@/auth" // Referring to the auth.ts we just created
-export const { GET, POST } = handlers


### PR DESCRIPTION
Deleted the API route handler for NextAuth at src/app/api/auth/[...nextauth]/route.ts. This may be part of a refactor or migration of authentication logic.